### PR TITLE
提交问题： 开启耳返时，混音器输入回调中 赋值录音数据方法报错 -50；

### DIFF
--- a/media/AudioRecorder/AudioUnitRecorder.h
+++ b/media/AudioRecorder/AudioUnitRecorder.h
@@ -39,9 +39,10 @@
     // 是否开启了混音
     BOOL _enableMixer;
     NSString *_mixerPath;
-    AudioStreamBasicDescription _mixerStreamDesForInput;    // 混音器的输入数据格式
+    AudioStreamBasicDescription _mixerStreamDesForInput;     // 混音器的输入数据格式
     AudioStreamBasicDescription _mixerStreamDesForOutput;    // 混音器的输出数据格式
-    
+    AudioStreamBasicDescription _ioRecordStreamDesForOutput; // 麦克风的输出数据格式
+  
     // 是否耳返
     BOOL _isEnablePlayWhenRecord;
 }


### PR DESCRIPTION
问题描述： 开启耳返时，混音器的数据源回调mixerInputDataCallback 中，录音器一路的赋值数据方法报错 -50

解决方法：将混音器麦克风一路的数据流描述改为 麦克风的输出描述；